### PR TITLE
Mail zodb-dev@zope.org was broken.

### DIFF
--- a/documentation/guide/introduction.rst
+++ b/documentation/guide/introduction.rst
@@ -169,8 +169,7 @@ The author's ZODB project is described in a paper available here,
 `<http://www.amk.ca/python/writing/mx-architecture/>`_
 
 This document will always be a work in progress.  If you wish to suggest
-clarifications or additional topics, please send your comments to zodb-
-dev@zope.org.
+clarifications or additional topics, please send your comments to zodb-dev@zope.org.
 
 
 Acknowledgements


### PR DESCRIPTION
"zodb" was missing in the link of the html page.